### PR TITLE
Url /asyncmailer/ for admin only

### DIFF
--- a/asyncmailer/urls.py
+++ b/asyncmailer/urls.py
@@ -1,11 +1,8 @@
 """URLs for the asyncmailer app."""
-# from compat import url
+from compat import url
+from . import views
 
-# from . import views
-
-
-# urlpatterns = [
-#     url(r'^$',
-#         views.YourView.as_view(),
-#         name='asyncmailer_default'),
-# ]
+urlpatterns = [
+    url(r'^$', views.index),
+    #your urls append here
+]

--- a/asyncmailer/views.py
+++ b/asyncmailer/views.py
@@ -1,3 +1,14 @@
+from django.http.response import HttpResponse
+from django.http import HttpResponseForbidden
+
+# asyncmailer/ index page
+def index(request):
+    if (request.user.is_authenticated() and request.user.is_active and request.user.is_superuser):
+        return HttpResponse('admin')
+    else:
+        return HttpResponseForbidden()
+
+
 """Views for the asyncmailer app."""
 # from django.views.generic import TemplateView
 


### PR DESCRIPTION
when asyncmailer.urls is empty, there is an error.
I add url /asyncmailer/ for admin only.
Next one is add new templates.
